### PR TITLE
polling: correctly abort the ongoing data request when closing transport

### DIFF
--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -176,7 +176,6 @@ Polling.prototype.onDataRequest = function (req, res) {
     cleanup();
   }
 
-  req.abort = cleanup;
   req.on('close', onClose);
   req.on('data', onData);
   req.on('end', onEnd);
@@ -265,9 +264,8 @@ Polling.prototype.doClose = function (fn) {
   debug('closing');
 
   if (this.dataReq) {
-    // FIXME: should we do this?
     debug('aborting ongoing data request');
-    this.dataReq.abort();
+    this.dataReq.destroy();
   }
 
   if (this.writable) {

--- a/test/server.js
+++ b/test/server.js
@@ -733,6 +733,27 @@ describe('server', function () {
       });
     });
 
+    it('should abort the polling data request if it is ' +
+       'in progress', function (done) {
+      var engine = listen({ transports: [ 'polling' ] }, function (port) {
+        var socket = new eioc.Socket('http://localhost:%d'.s(port));
+
+        engine.on('connection', function (conn) {
+          var onDataRequest = conn.transport.onDataRequest;
+          conn.transport.onDataRequest = function (req, res) {
+            engine.httpServer.close(done);
+            onDataRequest.call(conn.transport, req, res);
+            req.removeAllListeners();
+            conn.close();
+          };
+        });
+
+        socket.on('open', function () {
+          socket.send('test');
+        });
+      });
+    });
+
     // tests https://github.com/LearnBoost/engine.io-client/issues/207
     // websocket test, transport error
     it('should trigger transport close before open for ws', function(done){


### PR DESCRIPTION
A data request is "aborted" if the transport gets closed when the request is still in progress, but the abort procedure will only removes the listeners without actually closing the request.

This results in a pending request that is never responded.

As proof consider the following example:
```js
var Client = require('engine.io-client')
  , Engine = require('engine.io')
  , http = require('http');

var server = http.createServer()
  , engine = new Engine();

engine.on('connection', function connection(socket) {
  var onDataRequest = socket.transport.onDataRequest;

  socket.transport.onDataRequest = function (req, res) {
    onDataRequest.call(socket.transport, req, res);
    socket.close();
  };

  socket.on('message', function (data) {
    console.log(data);
  });
});

server.on('request', function request(req, res) {
  engine.handleRequest(req, res);
});

server.listen(function () {
  var client = new Client('http://localhost:' + server.address().port, {
    transports: [ 'polling' ]
  });

  client.on('open', function open() {
    client.send('bar');
  });

  client.on('close', function close() {
    server.close();
  });
});
```

This patch ensures that every data request gets closed correctly.
