### PR TITLE
server: add ability to enable/disable the permessage-deflate extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ to a single process.
         rejected, and err is an error code.
       - `transports` (`<Array> String`): transports to allow connections
         to (`['polling', 'websocket']`)
+      - `perMessageDeflate` (`Boolean`) whether to allow the WebSocket
+        permessage-deflate extension (`true`)
       - `allowUpgrades` (`Boolean`): whether to allow transport upgrades
         (`true`)
       - `cookie` (`String|Boolean`): name of the HTTP cookie that

--- a/lib/server.js
+++ b/lib/server.js
@@ -41,13 +41,18 @@ function Server(opts){
   this.upgradeTimeout = opts.upgradeTimeout || 10000;
   this.maxHttpBufferSize = opts.maxHttpBufferSize || 10E7;
   this.transports = opts.transports || Object.keys(transports);
+  this.perMessageDeflate = false !== opts.perMessageDeflate;
   this.allowUpgrades = false !== opts.allowUpgrades;
   this.allowRequest = opts.allowRequest;
   this.cookie = false !== opts.cookie ? (opts.cookie || 'io') : false;
 
   // initialize websocket server
   if (~this.transports.indexOf('websocket')) {
-    this.ws = new WebSocketServer({ noServer: true, clientTracking: false });
+    this.ws = new WebSocketServer({
+      perMessageDeflate: this.perMessageDeflate,
+      clientTracking: false,
+      noServer: true
+    });
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "debug": "1.0.3",
-    "ws": "0.5.0",
+    "ws": "0.6.3",
     "engine.io-parser": "1.1.0",
     "base64id": "0.1.0"
   },


### PR DESCRIPTION
This adds a new server option to enable/disable the newly introduced `permessage-deflate` extension in `ws`.
The default value is `true`.