### PR TITLE
Updated ws package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "debug": "1.0.3",
-    "ws": "0.5.0",
+    "ws": "~0.6.5",
     "engine.io-parser": "1.2.1",
     "base64id": "0.1.0"
   },


### PR DESCRIPTION
Currently engine.io and engine.io-client are using different versions of the slow installing ws. This unifies those versions.

Changes: https://github.com/einaros/ws/compare/0.5.0...0.6.5