### PR TITLE
package: bump `ws`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "debug": "1.0.3",
-    "ws": "0.6.5",
+    "ws": "0.7.1",
     "engine.io-parser": "1.2.1",
     "base64id": "0.1.0",
     "accepts": "1.1.4"


### PR DESCRIPTION
`ws@0.7` uses `optionalDependencies` and a fall back mechanism to ensure that installation works even when native modules fail to compile. 
See https://github.com/3rd-Eden/engine.io-client/commit/81374e1ff2eee5db01b7eaffe6ed22116559d42a.