### PR TITLE
support custom socket id

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,12 @@ to a single process.
       - `path` (`String`): name of the path to capture (`/engine.io`).
       - `destroyUpgrade` (`Boolean`): destroy unhandled upgrade requests (`true`)
       - `destroyUpgradeTimeout` (`Number`): milliseconds after which unhandled requests are ended (`1000`)
+- `generateId`
+    - Generate a socket id.
+    - Overwrite this method to generate your custom socket id.
+    - **Parameters**
+      - `http.ServerRequest`: a node request object
+  - **Returns** A socket id for connected client.
 
 <hr><br>
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -222,6 +222,18 @@ Server.prototype.handleRequest = function(req, res){
  }
 
 /**
+ * generate a socket id.
+ * Overwrite this method to generate your custom socket id
+ *
+ * @param {Object} request object
+ * @api public
+ */
+
+Server.prototype.generateId = function(req){
+  return base64id.generateId();
+};
+
+/**
  * Handshakes a new client.
  *
  * @param {String} transport name
@@ -230,7 +242,7 @@ Server.prototype.handleRequest = function(req, res){
  */
 
 Server.prototype.handshake = function(transport, req){
-  var id = base64id.generateId();
+  var id = this.generateId(req);
 
   debug('handshaking client "%s"', id);
 

--- a/test/server.js
+++ b/test/server.js
@@ -120,6 +120,28 @@ describe('server', function () {
       });
     });
 
+    it('should register a new client with custom id', function (done) {
+      var engine = listen({ allowUpgrades: false }, function (port) {
+        expect(Object.keys(engine.clients)).to.have.length(0);
+        expect(engine.clientsCount).to.be(0);
+
+        var customId = 'CustomId' + Date.now();
+
+        engine.generateId = function(req) {
+          return customId;
+        };
+
+        var socket = new eioc.Socket('ws://localhost:%d'.s(port));
+        socket.once('open', function () {
+          expect(Object.keys(engine.clients)).to.have.length(1);
+          expect(engine.clientsCount).to.be(1);
+          expect(socket.id).to.be(customId);
+          expect(engine.clients[customId].id).to.be(customId);
+          done();
+        });
+      });
+    });
+
     it('should exchange handshake data', function (done) {
       var engine = listen({ allowUpgrades: false }, function (port) {
         var socket = new eioc.Socket('ws://localhost:%d'.s(port));


### PR DESCRIPTION
Enable to use session id as socket id. It is useful for client reconnecting (reconnect with the same id).